### PR TITLE
Hide empty <h1> if page does not have a title.

### DIFF
--- a/libo/templates/Layout/Page.ss
+++ b/libo/templates/Layout/Page.ss
@@ -1,14 +1,15 @@
-<% if IsFullWidth %>
-<% else %>
+<% if IsFullWidth %><% else %>
  <% include SideBar %>
  <div class="ThirdLevelPage FloatRight">
 <% end_if %>
 <% include Translations %>
 <div class="typography">
-		<h1>$Title</h1>
+		<% if Title %><h1>$Title</h1><% end_if %>
 	
 		$Content
 		$Form
 		$PageComments
 </div>
-<% if IsFullWidth %><% else %></div><% end_if %>
+<% if IsFullWidth %><% else %>
+ </div>
+<% end_if %>


### PR DESCRIPTION
 Required for subsite home pages like sr.libreoffice.org.
